### PR TITLE
drivers: ethernet: xlnx-gem: fix rx dma wrap arround fail

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -312,6 +312,37 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 		}
 	}
 
+	/* DMA Rx buffer used bit not clear error handling */
+
+	if ((reg_val & ETH_XLNX_GEM_IXR_RX_USED_BIT) != 0x00000000U) {
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			dev_conf->base_addr + ETH_XLNX_GEM_IDR_OFFSET);
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			dev_conf->base_addr + ETH_XLNX_GEM_ISR_OFFSET);
+		reg_val = sys_read32(dev_conf->base_addr +
+						ETH_XLNX_GEM_NWCTRL_OFFSET);
+		reg_val |= ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT;
+		sys_write32(reg_val, dev_conf->base_addr +
+						ETH_XLNX_GEM_NWCTRL_OFFSET);
+		struct eth_xlnx_gem_bd *bdptr;
+		uint32_t buf_iter;
+			bdptr = dev_data->rxbd_ring.first_bd;
+
+		for (buf_iter = 0; buf_iter < (dev_conf->rxbd_count - 1); buf_iter++) {
+			/* Clear 'used' bit -> BD is owned by the controller */
+			bdptr->ctrl = 0;
+			bdptr->addr = (uint32_t)dev_data->first_rx_buffer +
+			      (buf_iter * (uint32_t)dev_conf->rx_buffer_size);
+			++bdptr;
+		}
+		bdptr->ctrl = 0; /* BD is owned by the controller */
+		bdptr->addr = ((uint32_t)dev_data->first_rx_buffer +
+		      (buf_iter * (uint32_t)dev_conf->rx_buffer_size)) |
+		      ETH_XLNX_GEM_RXBD_WRAP_BIT;
+		sys_write32(ETH_XLNX_GEM_IXR_RX_USED_BIT,
+			    dev_conf->base_addr + ETH_XLNX_GEM_IER_OFFSET);
+	}
+
 	/*
 	 * Clear all interrupt status bits so that the interrupt is de-asserted
 	 * by the GEM. -> TXSR/RXSR are read/cleared by either eth_xlnx_gem_-

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -209,6 +209,7 @@
 
 /*
  * gem.net_ctrl:
+ * [18]		  Flush the next packet from the external RX DPRAM
  * [15]       Store 1588 receive timestamp in CRC field
  * [12]       Transmit zero quantum pause frame
  * [11]       Transmit pause frame
@@ -222,6 +223,7 @@
  * [02]       Enable receive
  * [01]       Local loopback mode
  */
+#define ETH_XLNX_GEM_NWCTRL_FLUSH_DPRAM_BIT		0x00040000
 #define ETH_XLNX_GEM_NWCTRL_RXTSTAMP_BIT		0x00008000
 #define ETH_XLNX_GEM_NWCTRL_ZEROPAUSETX_BIT		0x00001000
 #define ETH_XLNX_GEM_NWCTRL_PAUSETX_BIT			0x00000800


### PR DESCRIPTION
the xilinx gem rx dma need to handle the descriptors used bit when cpu take the data from dma. Once the dma descriptors fifo data is wrap arround, the Ethernet dma will fail on write data to the not used descriptors and it toggle the RX_USED_BIT error bit in isr. Thus, we handle the error in isr and reset the rx buffer.